### PR TITLE
Updated origin validation for rrweb in SDK

### DIFF
--- a/src/CampfireSDK.js
+++ b/src/CampfireSDK.js
@@ -14,7 +14,8 @@ class CampfireSDK {
 				// for a layer of security.
 
 				// Match (regexp) if origin is [https://(.+).feedback-interface]
-				if (e.origin === "http://localhost:5173") {
+				const validOriginRegExp = /https:\/\/feedback-interface\.(.*)/
+				if (validOriginRegExp.test(e.origin)) {
 					console.log("origin: ", e.origin)
 					new rrweb.record({
 						emit() {},


### PR DESCRIPTION
🔨 Changed origin validation for rrweb to match origin of production feedback interface (https://feedback-interface.USER_DOMAIN)